### PR TITLE
Decoding value from cookie

### DIFF
--- a/src/Kolemp/TimecopBundle/Service/RequestBasedTimeGenerator.php
+++ b/src/Kolemp/TimecopBundle/Service/RequestBasedTimeGenerator.php
@@ -85,7 +85,7 @@ class RequestBasedTimeGenerator
             return;
         }
 
-        $fakeTime = strtotime($fakeTimeString);
+        $fakeTime = strtotime(urldecode($fakeTimeString));
 
         if ($fakeTime === false) {
             throw new \InvalidArgumentException('Given fake time is invalid: '.$fakeTimeString);


### PR DESCRIPTION
Symfony 4 by default encodes values in a cookie and decodes it during reading. But if we want to keep this cookie across two applications where one is written in Symfony 4 but second in Symfony 2 or 3, we need to decode it manually. This PR makes cookie working across them